### PR TITLE
Implement ESP32 watchdog

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <ESPmDNS.h>
 #include <WiFiUdp.h>
 #include <ArduinoOTA.h>
+#include "esp_task_wdt.h"
 #include "config.h"
 #include "input_config.h"
 
@@ -187,6 +188,10 @@ void checkButtons() {
 void setup() {
     Serial.begin(115200);
 
+    // Initialize watchdog: restart if loop is blocked for over 10 seconds
+    esp_task_wdt_init(10, true);
+    esp_task_wdt_add(NULL);
+
     MQTT_DEBUG_F("Starting Doorbell...");
     
     // Initialize EEPROM
@@ -309,6 +314,9 @@ void setup() {
 
 void loop() {
     ArduinoOTA.handle();
+
+    // Feed watchdog to prevent unwanted resets
+    esp_task_wdt_reset();
     
     if (!mqtt.connected()) {
         reconnect();


### PR DESCRIPTION
## Summary
- add esp_task_wdt.h include
- initialize watchdog in setup()
- feed watchdog each loop iteration

## Testing
- `python -m py_compile mqtt_to_ntfy.py mqtt_to_pushover.py session_logger.py`
- `pio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840133c5ba0832792fafb22c2ed67e8